### PR TITLE
Fix addTraceInfoByDistributor and addTraceInfoByRetailer methods

### DIFF
--- a/sample_1/contract/FoodInfoItem.sol
+++ b/sample_1/contract/FoodInfoItem.sol
@@ -32,14 +32,17 @@ contract FoodInfoItem{
         _owner = msg.sender;
     }
 
-    function addTraceInfoByDistributor( ①, uint8 quality) public returns(bool) {
+    function addTraceInfoByDistributor(string traceName, uint8 quality) public returns(bool) {
         require(_status == 0 , "status must be producing");
         //② 参数判定：只有合约部署者才可以调用该方法
+        require(msg.sender == _owner, "Only the contract owner can call this method");
         _timestamp.push(now);
         _traceName.push(traceName);
         _currentTraceName = traceName;
         //③
-        //④
+        _traceAddress.push(msg.sender);
+        //④1
+        _quality = quality;
         _traceQuality.push(_quality);
         _status = 1;
         return true;
@@ -67,11 +70,14 @@ contract FoodInfoItem{
     function addTraceInfoByRetailer( ①, uint8 quality) public returns(bool) {
         require(_status == 1 , "status must be distributing");
         //② 参数判定：只有合约部署者才可以调用该方法
+        require(msg.sender == _owner, "Only the contract owner can call this method");
         _timestamp.push(now);
         _traceName.push(traceName);
         _currentTraceName = traceName;
         //③
+        _traceAddress.push(msg.sender);
         //④
+        _quality = quality;
         _traceQuality.push(_quality);
         _status = 2;
         return true;

--- a/sample_1/contract/Trace.sol
+++ b/sample_1/contract/Trace.sol
@@ -18,10 +18,9 @@ contract Trace is Producer, Distributor, Retailer{
         uint[]  foodList;
 
         //构造函数
-        constructor(address producer, address distributor, address retailer)
-	public Producer(producer)
-	Distributor(distributor)
-	Retailer(retailer){
+        constructor(address producer, address distributor, address retailer) public Producer(producer)
+            Distributor(distributor)
+	        Retailer(retailer){
 
         }
         //生成食品溯源信息接口
@@ -29,15 +28,19 @@ contract Trace is Producer, Distributor, Retailer{
         //name 食品名称
         //traceNumber 食品溯源id
         //traceName 当前用户名称
-	//quality 当前食品质量
-        function newFood(①, string traceName, uint8 quality)
-	public ② returns(③)
+	    //quality 当前食品质量
+        function newFood(string name, uint256 traceNumber,string traceName, uint8 quality) public onlyProducer returns(address)
         {
             //④ 条件判定：traceNumber 已经存在
+            require(traceNumber == address(0), "traceNumber already exists");
             //⑤
+            FoodInfoItem food = new FoodInfoItem(name, traceName, quality, msg.sender);
             //⑥
+            foods[traceNumber] = address(food);
             //⑦
+            foodList.push(traceNumber);
             //⑧
+            return address(food);
 
             // int count = 0;
             // Table table = tf.openTable(TABLE_NAME);


### PR DESCRIPTION
This pull request fixes the addTraceInfoByDistributor and addTraceInfoByRetailer methods in the FoodInfoItem contract. It ensures that only the contract owner can call these methods and adds the trace address and quality to the trace information.